### PR TITLE
Fix DeprecationWarning: Update Adam optimizer 'lr' to 'learning_rate'

### DIFF
--- a/Quantum_CNN_for_HEP_Eraraya_Ricardo_Muten/development notebooks/QCNN v0.3.0.ipynb
+++ b/Quantum_CNN_for_HEP_Eraraya_Ricardo_Muten/development notebooks/QCNN v0.3.0.ipynb
@@ -1547,7 +1547,7 @@
         "outputId": "6d5f0bc5-9609-479c-9cc5-a27cd82e1848"
       },
       "source": [
-        "opt_adam = tf.keras.optimizers.Adam(lr=lr_schedule(0))"
+        "opt_adam = tf.keras.optimizers.Adam(learning_rate=lr_schedule(0))"
       ],
       "execution_count": 36,
       "outputs": [


### PR DESCRIPTION
Hi team! While reviewing the 2021 QCNN codebase, I noticed the model compilation step uses the deprecated lr argument in tf.keras.optimizers.Adam. In modern versions of TensorFlow (2.11+), this throws an AttributeError and crashes the notebook. I have updated it to the modern learning_rate argument to ensure forward compatibility. Let me know if you'd like me to check the other notebooks for similar Keras deprecations!